### PR TITLE
add docs for Ajax.crossOrigin flag

### DIFF
--- a/src/goo/util/Ajax.js
+++ b/src/goo/util/Ajax.js
@@ -90,7 +90,13 @@ define([
 	};
 
 	Ajax.ARRAY_BUFFER = 'arraybuffer';
+
+	/**
+	 * Allow cross-origin requests (CORS) for images.
+	 * @type {boolean} [crossOrigin=false]
+	 */
 	Ajax.crossOrigin = false;
+
 
 	var MIME_TYPES = {
 		mp4: 'video/mp4',


### PR DESCRIPTION
In order to use CORS textures the flag `Ajax.crossOrigin` needs to be set to `true`.