### PR TITLE
Entity Layers + physics collision matrix

### DIFF
--- a/src/goo/addons/physicspack/components/AbstractColliderComponent.js
+++ b/src/goo/addons/physicspack/components/AbstractColliderComponent.js
@@ -90,6 +90,7 @@ AbstractColliderComponent.prototype.attached = function (entity) {
  */
 AbstractColliderComponent.prototype.detached = function (/*entity*/) {
 	this.entity = null;
+	this.system = null;
 };
 
 /**

--- a/src/goo/addons/physicspack/components/ColliderComponent.js
+++ b/src/goo/addons/physicspack/components/ColliderComponent.js
@@ -180,7 +180,7 @@ ColliderComponent.updateLayerAndMask = function (entity) {
 	var cannonShape = entity.colliderComponent.cannonShape;
 	if (cannonShape) {
 		cannonShape.collisionFilterMask = entity._world.getSystem('PhysicsSystem').getLayerMask(layer);
-		cannonShape.collisionFilterGroup = layer;
+		cannonShape.collisionFilterGroup = Math.pow(2, layer);
 	}
 };
 

--- a/src/goo/addons/physicspack/components/ColliderComponent.js
+++ b/src/goo/addons/physicspack/components/ColliderComponent.js
@@ -46,6 +46,8 @@ ColliderComponent.type = 'ColliderComponent';
  * Initialize the collider as a static rigid body in the physics world.
  */
 ColliderComponent.prototype.initialize = function () {
+	var entity = this.entity;
+
 	var material = null;
 	if (this.material) {
 		material = new CANNON.Material();
@@ -56,10 +58,11 @@ ColliderComponent.prototype.initialize = function () {
 	var cannonShape = this.cannonShape = ColliderComponent.getCannonShape(this.worldCollider);
 	cannonShape.material = material;
 
+	this.updateLayerAndMask();
+
 	cannonShape.collisionResponse = !this.isTrigger;
 
 	// Get transform from entity
-	var entity = this.entity;
 	var transform = entity.transformComponent.sync().worldTransform;
 	var position = new CANNON.Vec3();
 	var quaternion = new CANNON.Quaternion();
@@ -165,6 +168,19 @@ ColliderComponent.applyOnEntity = function (obj, entity) {
 			collider: obj
 		}));
 		return true;
+	}
+};
+
+ColliderComponent.prototype.updateLayerAndMask = function () {
+	ColliderComponent.updateLayerAndMask(this.entity);
+};
+
+ColliderComponent.updateLayerAndMask = function (entity) {
+	var layer = entity.layer;
+	var cannonShape = entity.colliderComponent.cannonShape;
+	if (cannonShape) {
+		cannonShape.collisionFilterMask = entity._world.getSystem('PhysicsSystem').getLayerMask(layer);
+		cannonShape.collisionFilterGroup = layer;
 	}
 };
 

--- a/src/goo/addons/physicspack/components/RigidBodyComponent.js
+++ b/src/goo/addons/physicspack/components/RigidBodyComponent.js
@@ -773,6 +773,8 @@ RigidBodyComponent.prototype.addCollider = function (entity, position, quaternio
 
 	cannonShape.collisionResponse = !colliderComponent.isTrigger;
 
+	ColliderComponent.updateLayerAndMask(entity);
+
 	// Add the shape
 	var cannonPos = new CANNON.Vec3();
 	if (position) {

--- a/src/goo/addons/physicspack/systems/PhysicsSystem.js
+++ b/src/goo/addons/physicspack/systems/PhysicsSystem.js
@@ -113,25 +113,33 @@ PhysicsSystem.prototype = Object.create(AbstractPhysicsSystem.prototype);
 PhysicsSystem.prototype.constructor = PhysicsSystem;
 
 /**
+ * Make the system ignore (or un-ignore) collisions between layerA or layerB.
  * @param  {number} layerA
  * @param  {number} layerB
  * @param  {boolean} [ignore=true]
  */
 PhysicsSystem.prototype.ignoreLayerCollision = function (layerA, layerB, ignore) {
 	ignore = ignore !== undefined ? ignore : true;
-	var indexA = Math.log2(layerA);
-	var indexB = Math.log2(layerB);
+	var maskA = Math.pow(2, layerA);
+	var maskB = Math.pow(2, layerB);
 	var masks = this.masks;
 	if (ignore) {
-		masks[indexA] |= layerB;
-		masks[indexB] |= layerA;
+		masks[layerA] &= ~maskB;
+		masks[layerB] &= ~maskA;
 	} else {
-		masks[indexA] &= ~layerB;
-		masks[indexB] &= ~layerA;
+		masks[layerA] |= maskB;
+		masks[layerB] |= maskA;
 	}
 
-	// TODO: update all physics components
 	this.updateLayersAndMasks();
+};
+
+/**
+ * @param  {number} layerA
+ * @param  {number} layerB
+ */
+PhysicsSystem.prototype.getIgnoreLayerCollision = function (layerA, layerB) {
+	return !(this.masks[layerA] & Math.pow(2, layerB));
 };
 
 PhysicsSystem.prototype.updateLayersAndMasks = function () {
@@ -142,22 +150,12 @@ PhysicsSystem.prototype.updateLayersAndMasks = function () {
 };
 
 /**
- * @param  {number} layerA
- * @param  {number} layerB
- */
-PhysicsSystem.prototype.getIgnoreLayerCollision = function (layerA, layerB) {
-	var indexA = Math.log2(layerA);
-	return !!(this.masks[indexA] & layerB);
-};
-
-/**
  * Returns the current layer mask for the given layer.
  * @param  {number} layer
  * @return {number}
  */
 PhysicsSystem.prototype.getLayerMask = function (layer) {
-	var index = Math.log2(layer);
-	return this.masks[index];
+	return this.masks[layer];
 };
 
 /**

--- a/src/goo/entities/Entity.js
+++ b/src/goo/entities/Entity.js
@@ -64,6 +64,11 @@ function Entity(world, name, id) {
 	 */
 	this.static = false;
 
+	/** Entity layer.
+	 * @type {number}
+	 */
+	this.layer = 1;
+
 	Entity.entityCount++;
 }
 Entity.prototype = Object.create(EventTarget.prototype);

--- a/src/goo/entities/Entity.js
+++ b/src/goo/entities/Entity.js
@@ -64,7 +64,7 @@ function Entity(world, name, id) {
 	 */
 	this.static = false;
 
-	this._layer = 1;
+	this._layer = 0;
 
 	Entity.entityCount++;
 }

--- a/src/goo/entities/Entity.js
+++ b/src/goo/entities/Entity.js
@@ -74,6 +74,7 @@ Entity.prototype.constructor = Entity;
 Object.defineProperties(Entity.prototype, {
 
 	/**
+	 * The layer the entity is in. A layer is in the range 0 to 31. Layers can be used for selective rendering from cameras or ignoring raycasts.
 	 * @target-class Entity layer member
 	 * @type {number}
 	 */

--- a/src/goo/entities/Entity.js
+++ b/src/goo/entities/Entity.js
@@ -64,15 +64,31 @@ function Entity(world, name, id) {
 	 */
 	this.static = false;
 
-	/** Entity layer.
-	 * @type {number}
-	 */
-	this.layer = 1;
+	this._layer = 1;
 
 	Entity.entityCount++;
 }
 Entity.prototype = Object.create(EventTarget.prototype);
 Entity.prototype.constructor = Entity;
+
+Object.defineProperties(Entity.prototype, {
+
+	/**
+	 * @target-class Entity layer member
+	 * @type {number}
+	 */
+	layer: {
+		get: function () {
+			return this._layer;
+		},
+		set: function (value) {
+			this._layer = value;
+			this.fire({
+				type: 'layerChanged'
+			});
+		}
+	}
+});
 
 //! AT: not sure if 'add' is a better name - need to search for something short and compatible with the other 'set' methods
 /**

--- a/src/goo/entities/World.js
+++ b/src/goo/entities/World.js
@@ -2,6 +2,7 @@ var Entity = require('./Entity');
 var EntityManager = require('./managers/EntityManager');
 var TransformComponent = require('./components/TransformComponent');
 var Manager = require('./managers/Manager');
+var LayerManager = require('./managers/LayerManager');
 var System = require('./systems/System');
 var Component = require('./components/Component');
 var EntitySelection = require('./EntitySelection');
@@ -76,6 +77,7 @@ function World(options) {
 	this._managers = [];
 	this._systems = [];
 
+	// Such antipattern. Should just add/change/remove entities directly.
 	this._addedEntities = [];
 	this._changedEntities = [];
 	this._removedEntities = [];
@@ -88,6 +90,12 @@ function World(options) {
 	 */
 	this.entityManager = new EntityManager();
 	this.setManager(this.entityManager);
+	
+	/**
+	 * @type {LayerManager}
+	 */
+	this.layerManager = new LayerManager();
+	this.setManager(this.layerManager);
 
 	this._components = [];
 

--- a/src/goo/entities/managers/EntityManager.js
+++ b/src/goo/entities/managers/EntityManager.js
@@ -6,9 +6,7 @@ var EntitySelection = require('../../entities/EntitySelection');
  * @extends Manager
  */
 function EntityManager() {
-	Manager.call(this);
-
-	this.type = 'EntityManager';
+	Manager.call(this, { type: 'EntityManager' });
 
 	this._entitiesById = new Map();
 	this._entitiesByIndex = new Map();

--- a/src/goo/entities/managers/LayerManager.js
+++ b/src/goo/entities/managers/LayerManager.js
@@ -1,0 +1,86 @@
+var Manager = require('./Manager');
+
+/**
+ * Handles all layers in the world.
+ * @extends Manager
+ */
+function LayerManager() {
+
+	// All the layer names
+	this.layers = [];
+
+	for (var i=0; i<32; i++) {
+		var name;
+		if (i === 0) {
+			name = 'Default';
+		} else {
+			name = 'Layer ' + i;
+		}
+		this.layers.push(name);
+	}
+}
+LayerManager.prototype = Object.create(Manager.prototype);
+LayerManager.prototype.constructor = LayerManager;
+
+/**
+ * Returns a layer mask given an array of layers.
+ * @param  {array} layers
+ * @return {number}
+ */
+LayerManager.prototype.getMaskFromLayers = function (layers) {
+	var mask = 0;
+	var l = layers.length;
+	while (l--) {
+		mask |= layers[l];
+	}
+	return mask;
+};
+
+/**
+ * Set the name of a layer.
+ * @param {number} layer
+ * @param {string} name
+ */
+LayerManager.prototype.setName = function (layer, name) {
+	var index = Math.log2(layer);
+	this.layers[index] = name;
+};
+
+/**
+ * Returns a layer mask given a set of layer names.
+ * @param {array} names
+ * @returns {number}
+ */
+LayerManager.prototype.getMaskFromNames = function (names) {
+	var l = names.length;
+	var layers = new Array(l);
+	while (l--) {
+		layers[l] = this.nameToLayer(names[l]);
+	}
+	return this.getMaskFromLayers(layers);
+};
+
+/**
+ * Returns the name of a layer.
+ * @param {number} layer
+ * @returns {string}
+ */
+LayerManager.prototype.layerToName = function (layer) {
+	var index = Math.log2(layer);
+	return this.layers[index];
+};
+
+/**
+ * Returns the layer for the given name, or 0 if the name does not exist.
+ * @param {string} name
+ * @returns {number}
+ */
+LayerManager.prototype.nameToLayer = function (name) {
+	var index = this.layers.indexOf(name);
+	if (index === -1) {
+		return -1;
+	}
+	return this.layers[index];
+};
+
+module.exports = LayerManager;

--- a/src/goo/entities/managers/LayerManager.js
+++ b/src/goo/entities/managers/LayerManager.js
@@ -6,7 +6,7 @@ var Manager = require('./Manager');
  */
 function LayerManager() {
 	Manager.call(this, { type: 'LayerManager' });
-	
+
 	// All the layer names
 	this.layers = [];
 
@@ -32,7 +32,7 @@ LayerManager.prototype.getMaskFromLayers = function (layers) {
 	var mask = 0;
 	var l = layers.length;
 	while (l--) {
-		mask |= layers[l];
+		mask |= Math.pow(2, layers[l]);
 	}
 	return mask;
 };
@@ -43,8 +43,7 @@ LayerManager.prototype.getMaskFromLayers = function (layers) {
  * @param {string} name
  */
 LayerManager.prototype.setName = function (layer, name) {
-	var index = Math.log2(layer);
-	this.layers[index] = name;
+	this.layers[layer] = name;
 };
 
 /**
@@ -67,21 +66,16 @@ LayerManager.prototype.getMaskFromNames = function (names) {
  * @returns {string}
  */
 LayerManager.prototype.layerToName = function (layer) {
-	var index = Math.log2(layer);
-	return this.layers[index];
+	return this.layers[layer];
 };
 
 /**
- * Returns the layer for the given name, or 0 if the name does not exist.
+ * Returns the layer for the given name, or -1 if the name does not exist.
  * @param {string} name
  * @returns {number}
  */
 LayerManager.prototype.nameToLayer = function (name) {
-	var index = this.layers.indexOf(name);
-	if (index === -1) {
-		return -1;
-	}
-	return this.layers[index];
+	return this.layers.indexOf(name);
 };
 
 module.exports = LayerManager;

--- a/src/goo/entities/managers/LayerManager.js
+++ b/src/goo/entities/managers/LayerManager.js
@@ -5,7 +5,8 @@ var Manager = require('./Manager');
  * @extends Manager
  */
 function LayerManager() {
-
+	Manager.call(this, { type: 'LayerManager' });
+	
 	// All the layer names
 	this.layers = [];
 

--- a/src/goo/entities/managers/Manager.js
+++ b/src/goo/entities/managers/Manager.js
@@ -1,9 +1,26 @@
 /**
  * Base class for managers.
+ * @param {object} [options]
+ * @param {string} [options.type]
  */
-function Manager() {
+function Manager(options) {
+	options = options || {};
+	
+	this.type = options.type;
 	this.installedAPI = {};
 }
+
+/**
+ * Called when an entity was added to the World.
+ * @param {Entity} entity
+ */
+Manager.prototype.added = function (/*entity*/) {};
+
+/**
+ * Called when an entity was removed from the World.
+ * @param {Entity} entity
+ */
+Manager.prototype.removed = function (/*entity*/) {};
 
 Manager.prototype.applyAPI = function (worldBy) {
 	var api = this.api;

--- a/src/goo/loaders/handlers/EntityHandler.js
+++ b/src/goo/loaders/handlers/EntityHandler.js
@@ -89,7 +89,7 @@ EntityHandler.prototype._update = function (ref, config, options) {
 		if (!entity) { return; }
 		entity.id = ref;
 		entity.name = config.name;
-		entity.layer = config.layer;
+		entity.layer = config.layer !== undefined ? config.layer : 0;
 		entity.static = !!config.static;
 
 		updateTags(entity, config.tags);

--- a/src/goo/loaders/handlers/EntityHandler.js
+++ b/src/goo/loaders/handlers/EntityHandler.js
@@ -89,6 +89,7 @@ EntityHandler.prototype._update = function (ref, config, options) {
 		if (!entity) { return; }
 		entity.id = ref;
 		entity.name = config.name;
+		entity.layer = config.layer;
 		entity.static = !!config.static;
 
 		updateTags(entity, config.tags);

--- a/test/unit/addons/physicspack/components/ColliderComponent-test.js
+++ b/test/unit/addons/physicspack/components/ColliderComponent-test.js
@@ -37,6 +37,18 @@ describe('ColliderComponent', function () {
 		expect(colliderComponent.worldCollider.radius).toBe(3);
 	});
 
+	it('updates its mask and layer', function () {
+		var colliderComponent = new ColliderComponent({
+			collider: new SphereCollider({ radius: 1 })
+		});
+		var entity = world.createEntity(colliderComponent).addToWorld();
+		var layer = Math.pow(2, 4);
+		entity.layer = layer;
+		colliderComponent.initialize();
+
+		expect(colliderComponent.cannonShape.collisionFilterGroup).toBe(layer);
+	});
+
 	it('instantiates as a static body without a rigid body component', function () {
 		var material = new PhysicsMaterial({
 			friction: 0.6,

--- a/test/unit/addons/physicspack/components/ColliderComponent-test.js
+++ b/test/unit/addons/physicspack/components/ColliderComponent-test.js
@@ -46,9 +46,6 @@ describe('ColliderComponent', function () {
 		entity.layer = layer;
 		system.ignoreLayerCollision(4,5);
 
-		expect(system.getIgnoreLayerCollision(4,5)).toBeTruthy();
-		expect(system.getIgnoreLayerCollision(4,6)).toBeFalsy();
-
 		colliderComponent.initialize();
 
 		expect(colliderComponent.cannonShape.collisionFilterGroup).toBe(Math.pow(2, 4));

--- a/test/unit/addons/physicspack/components/ColliderComponent-test.js
+++ b/test/unit/addons/physicspack/components/ColliderComponent-test.js
@@ -42,11 +42,17 @@ describe('ColliderComponent', function () {
 			collider: new SphereCollider({ radius: 1 })
 		});
 		var entity = world.createEntity(colliderComponent).addToWorld();
-		var layer = Math.pow(2, 4);
+		var layer = 4;
 		entity.layer = layer;
+		system.ignoreLayerCollision(4,5);
+
+		expect(system.getIgnoreLayerCollision(4,5)).toBeTruthy();
+		expect(system.getIgnoreLayerCollision(4,6)).toBeFalsy();
+
 		colliderComponent.initialize();
 
-		expect(colliderComponent.cannonShape.collisionFilterGroup).toBe(layer);
+		expect(colliderComponent.cannonShape.collisionFilterGroup).toBe(Math.pow(2, 4));
+		expect(colliderComponent.cannonShape.collisionFilterMask).toBe(-1 & (~Math.pow(2, 5)));
 	});
 
 	it('instantiates as a static body without a rigid body component', function () {

--- a/test/unit/addons/physicspack/systems/PhysicsSystem-test.js
+++ b/test/unit/addons/physicspack/systems/PhysicsSystem-test.js
@@ -140,11 +140,11 @@ describe('PhysicsSystem', function () {
 		rbc.initialize(); // Needed to initialize body
 
 		var result = new RaycastResult();
-		system.raycastAny(start, direction, distance, { collisionGroup: -1 }, result);
+		system.raycastAny(start, direction, distance, { collisionMask: -1 }, result);
 		expect(result.entity).toBeTruthy();
 
 		result = new RaycastResult();
-		system.raycastAny(start, direction, distance, { collisionGroup: 2 }, result);
+		system.raycastAny(start, direction, distance, { collisionMask: 2 }, result);
 		expect(result.entity).toBeFalsy();
 	});
 

--- a/test/unit/addons/physicspack/systems/PhysicsSystem-test.js
+++ b/test/unit/addons/physicspack/systems/PhysicsSystem-test.js
@@ -793,4 +793,22 @@ describe('PhysicsSystem', function () {
 		system.play();
 		world.fixedUpdate();
 	});
+
+	it('can ignore layer collision', function () {
+		system.ignoreLayerCollision(4,5);
+
+		expect(system.getIgnoreLayerCollision(4,5)).toBeTruthy();
+		expect(system.getIgnoreLayerCollision(4,6)).toBeFalsy();
+
+		system.ignoreLayerCollision(4,5, false);
+
+		expect(system.getIgnoreLayerCollision(4,5)).toBeFalsy();
+	});
+
+	it('can get a layer mask', function () {
+		system.ignoreLayerCollision(4,5);
+
+		var mask = system.getLayerMask(4);
+		expect(mask).toBe(-1 & (~Math.pow(2, 5))); // Everything minus 5
+	});
 });


### PR DESCRIPTION
* Added a `.layer` property to Entity instances.
* Added `LayerManager` that keeps all layer names. Can be used to convert between name and layer. Good to have when this stuff gets into Create.
* `PhysicsSystem` has a "collision matrix" with information about what layer collides with what.
* Colliders update their masks on initialize() depending on the "collision matrix" in the `PhysicsSystem`.